### PR TITLE
feat: 공지상세페이지 진입 시 Loader 적용

### DIFF
--- a/src/app/(pages)/notice/[id]/page.tsx
+++ b/src/app/(pages)/notice/[id]/page.tsx
@@ -71,7 +71,7 @@ export default function NoticeDetailPage() {
   if (!notice)
     return (
       <div className='text-sm text-[rgba(255,255,255,1)] text-center py-10'>
-        공지사항을 찾을 수 없습니다.
+        {/* 공지사항을 찾을 수 없습니다. */}
       </div>
     );
 

--- a/src/app/(pages)/notice/[id]/page.tsx
+++ b/src/app/(pages)/notice/[id]/page.tsx
@@ -6,6 +6,7 @@ import { TopBar } from '@/app/_common/components/top-bar';
 import { getNoticeDetail } from '@/app/_common/apis/notice.api';
 import { type NoticeDetailResponse } from '@/app/_common/interfaces/notice.interface';
 import ImageModal from './_components/ImageModal';
+import { Loader } from '@/app/_common/components/loader';
 
 export default function NoticeDetailPage() {
   const { id } = useParams();
@@ -68,12 +69,21 @@ export default function NoticeDetailPage() {
     };
   }, [isModalOpen]);
 
-  if (!notice)
+  if (loading) {
     return (
-      <div className='text-sm text-[rgba(255,255,255,1)] text-center py-10'>
-        {/* 공지사항을 찾을 수 없습니다. */}
+      <div className='p-6 size-full flex items-center justify-center text-sm text-gray-500'>
+        <Loader />
       </div>
     );
+  }
+
+  if (!notice) {
+    return (
+      <div className='text-sm text-[rgba(255,255,255,1)] text-center py-10'>
+        공지사항을 찾을 수 없습니다.
+      </div>
+    );
+  }
 
   const formatDate = (iso: string) => {
     const date = new Date(iso);


### PR DESCRIPTION
## #️⃣ 변경점이 무엇인가요?

![KakaoTalk_Photo_2025-05-27-01-36-30](https://github.com/user-attachments/assets/2ca2c75f-f1b6-4228-a929-c9a0d013eb2c)
<img width="285" alt="스크린샷 2025-05-27 오전 1 36 07" src="https://github.com/user-attachments/assets/8459f75c-9bd9-4912-b844-592ccb0b277e" />


> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 공지상세페이지 진입 시 "공지사항을 불러올 수 없음" 문제 해결했습니다 (loading 적용함) 

## 다른 팀원들이 알아야하는 사항이 있나요?

> 서비스 전체에 영향을 주는 변경에 대한 설명을 해주세요
> 없습니다

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 없습니다
